### PR TITLE
Fix tests dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ Quart==0.20.0
 typing_extensions==4.12.2
 Werkzeug==3.1.3
 wsproto==1.2.0
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- add missing httpx dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683f5c0cfd6c8326910358ac70cb4262